### PR TITLE
docs: Use correct URL for repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
  Under development - not at all polished!
 
-This web-book website can be found here: [https://gordonwatts.github.io/xaod_usage/chapters/met.html](https://gordonwatts.github.io/xaod_usage).
+This web-book website can be found here: [https://gordonwatts.github.io/xaod_usage/](https://gordonwatts.github.io/xaod_usage).
 
 ## Updating The Book
 

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -28,9 +28,9 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
+  url: https://github.com/gordonwatts/xaod_usage  # Online location of your book's source code
   path_to_book: docs  # Optional path to your book, relative to the repository root
-  branch: master  # Which branch of the repository should be used when creating links (optional)
+  branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
* Update the repository URL to point to the GitHub source repository.
   - Use 'main' as branch name.
* Update URL in README to display the default page.